### PR TITLE
Implement vaccination set operations example in C#

### DIFF
--- a/CovidVaccination/CovidVaccination.csproj
+++ b/CovidVaccination/CovidVaccination.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/CovidVaccination/Program.cs
+++ b/CovidVaccination/Program.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+
+class Program
+{
+    static void Main()
+    {
+        // Generate 500 citizens
+        List<string> citizens = new List<string>();
+        for (int i = 1; i <= 500; i++)
+        {
+            citizens.Add($"Ciudadano {i}");
+        }
+
+        Random rand = new Random();
+        HashSet<string> pfizer = new HashSet<string>();
+        HashSet<string> astrazeneca = new HashSet<string>();
+
+        // 75 vaccinated with Pfizer
+        while (pfizer.Count < 75)
+        {
+            pfizer.Add(citizens[rand.Next(citizens.Count)]);
+        }
+
+        // 75 vaccinated with AstraZeneca
+        while (astrazeneca.Count < 75)
+        {
+            astrazeneca.Add(citizens[rand.Next(citizens.Count)]);
+        }
+
+        // Citizens with both doses
+        HashSet<string> both = new HashSet<string>(pfizer);
+        both.IntersectWith(astrazeneca);
+
+        // Citizens only vaccinated with Pfizer
+        HashSet<string> onlyPfizer = new HashSet<string>(pfizer);
+        onlyPfizer.ExceptWith(astrazeneca);
+
+        // Citizens only vaccinated with AstraZeneca
+        HashSet<string> onlyAstra = new HashSet<string>(astrazeneca);
+        onlyAstra.ExceptWith(pfizer);
+
+        // Citizens not vaccinated
+        HashSet<string> vaccinated = new HashSet<string>(pfizer);
+        vaccinated.UnionWith(astrazeneca);
+        HashSet<string> unvaccinated = new HashSet<string>(citizens);
+        unvaccinated.ExceptWith(vaccinated);
+
+        // Print results
+        Console.WriteLine($"Total ciudadanos: {citizens.Count}");
+        Console.WriteLine($"Vacunados con Pfizer: {pfizer.Count}");
+        Console.WriteLine($"Vacunados con AstraZeneca: {astrazeneca.Count}");
+        Console.WriteLine($"No vacunados: {unvaccinated.Count}");
+        Console.WriteLine($"Ambas vacunas: {both.Count}");
+        Console.WriteLine($"Solo Pfizer: {onlyPfizer.Count}");
+        Console.WriteLine($"Solo AstraZeneca: {onlyAstra.Count}");
+
+        // Display lists
+        PrintSet("No vacunados", unvaccinated);
+        PrintSet("Ambas vacunas", both);
+        PrintSet("Solo Pfizer", onlyPfizer);
+        PrintSet("Solo AstraZeneca", onlyAstra);
+    }
+
+    static void PrintSet(string title, HashSet<string> set)
+    {
+        Console.WriteLine($"\n{title} ({set.Count}):");
+        foreach (var c in set)
+        {
+            Console.WriteLine(c);
+        }
+    }
+}
+

--- a/CovidVaccination/README.md
+++ b/CovidVaccination/README.md
@@ -1,0 +1,20 @@
+# Campaign Vaccination Data
+
+This console application generates a fictitious list of 500 citizens and randomly assigns vaccinations:
+
+- 75 citizens vaccinated with Pfizer
+- 75 citizens vaccinated with AstraZeneca
+
+Using set theory operations it produces:
+
+- Citizens that have not been vaccinated
+- Citizens that received both vaccines
+- Citizens that only received the Pfizer vaccine
+- Citizens that only received the AstraZeneca vaccine
+
+To run the program you need the .NET SDK installed:
+
+```bash
+dotnet run --project CovidVaccination
+```
+


### PR DESCRIPTION
## Summary
- add a C# console app that generates 500 mock citizens and randomly assigns Pfizer and AstraZeneca vaccinations
- compute unvaccinated, both doses, only Pfizer, and only AstraZeneca using set operations
- document how to run the sample

## Testing
- `dotnet build CovidVaccination/CovidVaccination.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abd25e5a2483308147197a000875a3